### PR TITLE
Remove .env 

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,0 @@
-NEXT_PUBLIC_SERVICE_ID=service_id
-NEXT_PUBLIC_TEMPLATE_ID=template_id
-NEXT_PUBLIC_USER_ID=user_id
-DATABASE_URL="postgresql://"


### PR DESCRIPTION
.env is ignored by git according to .gitignore, but the .env already on the repo should be removed so we don't have .env changes marked as `not staged for commit` 

```
(removed .env + committed, then created new .env)
--- 

$ ls -a
.        .babelrc    _digest  .eslintrc       _events  .gitignore  next.config.js  package-lock.json  .prettierrc.json  README.md  utils
..       cache       _direct  .eslintrc.json  .git     lib         node_modules    pages              prisma            sections
_author  components  .env     .estlintignore  .github  .next       package.json    .prettierignore    public            theme
$ git status
On branch remove-env
nothing to commit, working tree clean // new .env is ignored
```
Add instructions/template for creating .env file after cloning