### PR TITLE
UAS 3 step

### DIFF
--- a/components/StudentResource.jsx
+++ b/components/StudentResource.jsx
@@ -62,7 +62,7 @@ const Graphic = styled.div`
 `;
 
 const Wrapper = styled.div`
-  padding: 8vh 0;
+  padding: 4vh 0;
   display: flex;
   ${({ isgraphicleft }) => `
     flex-direction: ${isgraphicleft ? "row" : "row-reverse"}

--- a/components/StudentResource.jsx
+++ b/components/StudentResource.jsx
@@ -17,18 +17,18 @@ export const StudentResource = ({
   isGraphicLeft = true,
   ...props
 }) => (
-  <Wrapper isgraphicleft={isGraphicLeft} {...props}>
+  <Wrapper isgraphicleft={isGraphicLeft ? 1 : 0} {...props}>
     <Graphic
       src={graphic}
       width={graphicWidth}
       height={graphicHeight}
-      isgraphicleft={isGraphicLeft}
+      isgraphicleft={isGraphicLeft ? 1 : 0}
     />
-    <InfoSection isgraphicleft={isGraphicLeft}>
+    <InfoSection isgraphicleft={isGraphicLeft ? 1 : 0}>
       <Title>{titleText}</Title>
       <Text>{descriptionText}</Text>
       {!!buttons && (
-        <ButtonSection isgraphicleft={isGraphicLeft}>
+        <ButtonSection isgraphicleft={isGraphicLeft ? 1 : 0}>
           {buttons.map((button) => (
             <Link key={button.text} href={button.link}>
               <a>

--- a/components/StudentResource.jsx
+++ b/components/StudentResource.jsx
@@ -34,7 +34,7 @@ export const StudentResource = ({
   isCard = false,
   ...props
 }) => (
-  <Wrapper isgraphicleft={isGraphicLeft} isCard={isCard} {...props}>
+  <Wrapper isgraphicleft={isGraphicLeft} iscard={isCard} {...props}>
     <Graphic isgraphicleft={isGraphicLeft ? 1 : 0}>
       <Image src={graphic} width={graphicWidth} height={graphicHeight} />
     </Graphic>
@@ -60,15 +60,15 @@ const Title = styled.h2`
   ${({ theme }) => `
       font-family: ${theme.font.josefin};
       color: ${theme.colors.black};
-  `};
-  margin: 0;
+      `};
+  margin: 3% 0 0;
 `;
 
 const Graphic = styled.div`
   /* TODO: curved border ? */
   ${({ isgraphicleft }) => `
-    ${isgraphicleft ? "margin-right: 5%;" : "margin-left: 5%;"}
-  `};
+      ${isgraphicleft ? "margin-right: 5%;" : "margin-left: 5%;"}
+      `};
   ${media(
     "tablet",
     `
@@ -81,8 +81,8 @@ const Wrapper = styled.div`
   padding: 4vh 0;
   display: flex;
   ${({ isgraphicleft }) => `
-    flex-direction: ${isgraphicleft ? "row" : "row-reverse"}
-  `};
+      flex-direction: ${isgraphicleft ? "row" : "row-reverse"}
+      `};
   align-items: center;
   justify-content: center;
   ${media(
@@ -98,26 +98,30 @@ const InfoSection = styled.div`
   display: flex;
   flex-direction: column;
   ${({ isgraphicleft, iscard, theme }) => `
-    text-align: ${isgraphicleft ? "left" : "right"};
-    box-shadow: ${iscard ? `${theme.boxShadow.topBottom}` : "none"};
-    border-radius: ${theme.radius.border};
-  `};
+      text-align: ${isgraphicleft ? "left" : "right"};
+      box-shadow: ${iscard ? `${theme.boxShadow.topBottom}` : "none"};
+      border-radius: ${theme.radius.border};
+      `};
   padding: 3%;
   ${media(
     "tablet",
     `
       text-align: center;
-      margin: 5% 0 0;
       width: 85%;
+      margin: 1rem 0 0;
     `
-  )}/* TODO: change text color based on background */
+  )};
+   {
+    /* TODO: change text color based on background */
+  }
 `;
 
 const ButtonSection = styled.div`
   display: flex;
-  ${({ isgraphicleft }) => `
-    justify-content: ${isgraphicleft ? "flex-start" : "flex-end"}
-  `};
+  ${({ isgraphicleft }) =>
+    `
+      justify-content: ${isgraphicleft ? "flex-start" : "flex-end"}
+    `};
   flex-flow: row wrap;
   ${media(
     "tablet",

--- a/components/StudentResource.jsx
+++ b/components/StudentResource.jsx
@@ -83,10 +83,13 @@ const InfoSection = styled.div`
   width: 35%;
   display: flex;
   flex-direction: column;
-  ${({ isgraphicleft }) => `
+  ${({ isgraphicleft, theme }) => `
     text-align: ${isgraphicleft ? "left" : "right"};
+    // TODO: make card optional prop 
+    box-shadow: ${theme.boxShadow.topBottom};
+    border-radius: ${theme.radius.border};
   `};
-  margin: 0% 5%;
+  padding: 3%;
   ${media(
     800,
     `

--- a/components/StudentResource.jsx
+++ b/components/StudentResource.jsx
@@ -12,19 +12,16 @@ export const StudentResource = ({
   descriptionText,
   buttons,
   graphic,
-  graphicWidth = 500,
+  graphicWidth = 400,
   graphicHeight = 350,
   isGraphicLeft = true,
   isCard = false,
   ...props
 }) => (
   <Wrapper isgraphicleft={isGraphicLeft} isCard={isCard} {...props}>
-    <Graphic
-      src={graphic}
-      width={graphicWidth}
-      height={graphicHeight}
-      isgraphicleft={isGraphicLeft ? 1 : 0}
-    />
+    <Graphic isgraphicleft={isGraphicLeft ? 1 : 0}>
+      <Image src={graphic} width={graphicWidth} height={graphicHeight} />
+    </Graphic>
     <InfoSection isgraphicleft={isGraphicLeft} iscard={isCard}>
       <Title>{titleText}</Title>
       <Text>{descriptionText}</Text>
@@ -51,15 +48,15 @@ const Title = styled.h2`
   margin: 0;
 `;
 
-const Graphic = styled(Image)`
+const Graphic = styled.div`
   /* TODO: curved border ? */
   ${({ isgraphicleft }) => `
-    ${isgraphicleft ? "margin-left: 5%;" : "margin-right: 5%;"}
+    ${isgraphicleft ? "margin-right: 5%;" : "margin-left: 5%;"}
   `};
   ${media(
-    "800",
+    "tablet",
     `
-      width: 70%;
+      margin: 0;
     `
   )}
 `;
@@ -73,7 +70,7 @@ const Wrapper = styled.div`
   align-items: center;
   justify-content: center;
   ${media(
-    800,
+    "tablet",
     `
       flex-direction: column;
     `
@@ -86,13 +83,12 @@ const InfoSection = styled.div`
   flex-direction: column;
   ${({ isgraphicleft, iscard, theme }) => `
     text-align: ${isgraphicleft ? "left" : "right"};
-    // TODO: make card optional prop 
     box-shadow: ${iscard ? `${theme.boxShadow.topBottom}` : "none"};
     border-radius: ${theme.radius.border};
   `};
   padding: 3%;
   ${media(
-    800,
+    "tablet",
     `
       text-align: center;
       margin: 5% 0 0;
@@ -108,7 +104,7 @@ const ButtonSection = styled.div`
   `};
   flex-flow: row wrap;
   ${media(
-    800,
+    "tablet",
     `
       justify-content: center;
     `

--- a/components/StudentResource.jsx
+++ b/components/StudentResource.jsx
@@ -7,6 +7,22 @@ import { Text } from "./Text";
 import { Button } from "./Button";
 import { media } from "../utils";
 
+/**
+ *
+ * Student Resource Component
+ * @prop {string} titleText - resource title
+ * @prop {string} descriptionText - resource description
+ * @prop {array} buttons - array of buttons with resource relevant links
+ * |- each button element should have text and link keys
+ * @prop {object} graphic - resource graphic
+ * @prop {number} graphicWidth - width of resource graphic, default 400
+ * @prop {number} graphicHeight - height of resource graphic, default 350
+ * @prop {boolean} isGraphicLeft - specify the location of the resource graphic
+ * |- default true (image on left, text on right)
+ * @prop {boolean} isCard - should the text + buttons look like a card, default false
+ * |- box shadow and rounded borders
+ */
+
 export const StudentResource = ({
   titleText,
   descriptionText,

--- a/components/StudentResource.jsx
+++ b/components/StudentResource.jsx
@@ -15,20 +15,21 @@ export const StudentResource = ({
   graphicWidth = 500,
   graphicHeight = 350,
   isGraphicLeft = true,
+  isCard = false,
   ...props
 }) => (
-  <Wrapper isgraphicleft={isGraphicLeft ? 1 : 0} {...props}>
+  <Wrapper isgraphicleft={isGraphicLeft} isCard={isCard} {...props}>
     <Graphic
       src={graphic}
       width={graphicWidth}
       height={graphicHeight}
       isgraphicleft={isGraphicLeft ? 1 : 0}
     />
-    <InfoSection isgraphicleft={isGraphicLeft ? 1 : 0}>
+    <InfoSection isgraphicleft={isGraphicLeft} iscard={isCard}>
       <Title>{titleText}</Title>
       <Text>{descriptionText}</Text>
       {!!buttons && (
-        <ButtonSection isgraphicleft={isGraphicLeft ? 1 : 0}>
+        <ButtonSection isgraphicleft={isGraphicLeft}>
           {buttons.map((button) => (
             <Link key={button.text} href={button.link}>
               <a>
@@ -83,10 +84,10 @@ const InfoSection = styled.div`
   width: 35%;
   display: flex;
   flex-direction: column;
-  ${({ isgraphicleft, theme }) => `
+  ${({ isgraphicleft, iscard, theme }) => `
     text-align: ${isgraphicleft ? "left" : "right"};
     // TODO: make card optional prop 
-    box-shadow: ${theme.boxShadow.topBottom};
+    box-shadow: ${iscard ? `${theme.boxShadow.topBottom}` : "none"};
     border-radius: ${theme.radius.border};
   `};
   padding: 3%;
@@ -126,4 +127,5 @@ StudentResource.propTypes = {
   graphicWidth: PropTypes.number,
   graphicHeight: PropTypes.number,
   isGraphicLeft: PropTypes.bool,
+  isCard: PropTypes.bool,
 };

--- a/pages/resources/uas.jsx
+++ b/pages/resources/uas.jsx
@@ -1,6 +1,6 @@
 import Head from "next/head";
 import { PageLayout } from "../../sections/hoc";
-import { UASLayout } from "../../sections/resources/uas";
+import { UASLayout, UAS3Step } from "../../sections/resources/uas";
 import { Title } from "../../components";
 
 export default function UAS() {
@@ -12,6 +12,7 @@ export default function UAS() {
       <PageLayout>
         <Title title="University Admissions Server (UAS)" arrowLink="/resources" />
         <UASLayout />
+        <UAS3Step />
       </PageLayout>
     </div>
   );

--- a/sections/resources/ResourcesSection.jsx
+++ b/sections/resources/ResourcesSection.jsx
@@ -53,16 +53,18 @@ export const ResourcesSection = () => {
     },
   ];
 
-  return resources.map((resource) => (
-    <StudentResource
-      key={resource.titleText}
-      titleText={resource.titleText}
-      descriptionText={resource.descriptionText}
-      buttons={resource.buttons}
-      graphic={resource.graphic}
-      graphicWidth={resource.graphicWidth}
-      graphicHeight={resource.graphicHeight}
-      isGraphicLeft={resource.isGraphicLeft}
-    />
-  ));
+  return resources.map(
+    (resource /* TODO: add wrapper to increase margin around resources */) => (
+      <StudentResource
+        key={resource.titleText}
+        titleText={resource.titleText}
+        descriptionText={resource.descriptionText}
+        buttons={resource.buttons}
+        graphic={resource.graphic}
+        graphicWidth={resource.graphicWidth}
+        graphicHeight={resource.graphicHeight}
+        isGraphicLeft={resource.isGraphicLeft}
+      />
+    )
+  );
 };

--- a/sections/resources/uas/UAS3Step.jsx
+++ b/sections/resources/uas/UAS3Step.jsx
@@ -30,7 +30,7 @@ export const UAS3Step = () => (
       titleText="3. Lounge Rooms"
       descriptionText={`A miscellaneous channel to learn more about each university's student life, network, and chat!`}
       graphic={SampleGraphic}
-      graphicHeight={250}
+      graphicWidth={250}
       isCard={true}
     />
     <div>

--- a/sections/resources/uas/UAS3Step.jsx
+++ b/sections/resources/uas/UAS3Step.jsx
@@ -67,6 +67,8 @@ const Title = styled.h2`
   font-weight: 900;
   padding-right: 20%;
   color: ${baseTheme.colors.navy};
+  font-family: ${baseTheme.font.josefin};
+  font-size: ${baseTheme.size.h2};
   ${media(
     "tablet",
     `

--- a/sections/resources/uas/UAS3Step.jsx
+++ b/sections/resources/uas/UAS3Step.jsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 
 import { StudentResource, Button } from "../../../components";
 import SampleGraphic from "../../../public/home/top-section-graphic.svg";
+import { baseTheme } from "../../../theme";
 import { media } from "../../../utils";
 
 export const UAS3Step = () => (
@@ -35,7 +36,7 @@ export const UAS3Step = () => (
     <div>
       <Link href="reources/uas">
         <a>
-    {/* TODO: change to discord server link */}
+          {/* TODO: change to discord server link */}
           <Button>Join our Community of 800+ Students!</Button>
         </a>
       </Link>
@@ -57,7 +58,7 @@ const TitleSection = styled.div`
   ${media(
     "tablet",
     `
-      justify-content: center; 
+      justify-content: center;
       `
   )};
 `;
@@ -65,10 +66,11 @@ const TitleSection = styled.div`
 const Title = styled.h2`
   font-weight: 900;
   padding-right: 20%;
+  color: ${baseTheme.colors.navy};
   ${media(
     "tablet",
     `
       padding-right: 0;
-      `
+    `
   )};
 `;

--- a/sections/resources/uas/UAS3Step.jsx
+++ b/sections/resources/uas/UAS3Step.jsx
@@ -1,0 +1,30 @@
+import styled from "styled-components";
+import { StudentResource } from "../../../components";
+import SampleGraphic from "../../../public/home/top-section-graphic.svg";
+
+export const UAS3Step = () => (
+  <div>
+    <StudentResource
+      titleText="1. FAQ Documents"
+      descriptionText={`Concise descriptions of each university program that will be pinned in each Discord channel for easy access. FAQ sheets will address basic information about the university program, such as grade cutoffs, testing requirements, course requirements, and core curriculum.`}
+      graphic={SampleGraphic}
+      graphicHeight={300}
+      isCard={true}
+    />
+    <StudentResource
+      titleText="2. Moderated Q&A"
+      descriptionText={`For topics not addressed in the FAQ, students are encouraged to use the Discord chat function to get their question answered directly by a current student/alumni of their program of interest`}
+      graphic={SampleGraphic}
+      graphicHeight={300}
+      isGraphicLeft={false}
+      isCard={true}
+    />
+    <StudentResource
+      titleText="3. Lounge Rooms"
+      descriptionText={`A miscellaneous channel to learn more about each university's student life, network, and chat!`}
+      graphic={SampleGraphic}
+      graphicHeight={300}
+      isCard={true}
+    />
+  </div>
+);

--- a/sections/resources/uas/UAS3Step.jsx
+++ b/sections/resources/uas/UAS3Step.jsx
@@ -1,4 +1,3 @@
-import styled from "styled-components";
 import { StudentResource } from "../../../components";
 import SampleGraphic from "../../../public/home/top-section-graphic.svg";
 
@@ -8,14 +7,14 @@ export const UAS3Step = () => (
       titleText="1. FAQ Documents"
       descriptionText={`Concise descriptions of each university program that will be pinned in each Discord channel for easy access. FAQ sheets will address basic information about the university program, such as grade cutoffs, testing requirements, course requirements, and core curriculum.`}
       graphic={SampleGraphic}
-      graphicHeight={300}
+      graphicWidth={250}
       isCard={true}
     />
     <StudentResource
       titleText="2. Moderated Q&A"
       descriptionText={`For topics not addressed in the FAQ, students are encouraged to use the Discord chat function to get their question answered directly by a current student/alumni of their program of interest`}
       graphic={SampleGraphic}
-      graphicHeight={300}
+      graphicWidth={250}
       isGraphicLeft={false}
       isCard={true}
     />
@@ -23,7 +22,7 @@ export const UAS3Step = () => (
       titleText="3. Lounge Rooms"
       descriptionText={`A miscellaneous channel to learn more about each university's student life, network, and chat!`}
       graphic={SampleGraphic}
-      graphicHeight={300}
+      graphicHeight={250}
       isCard={true}
     />
   </div>

--- a/sections/resources/uas/UAS3Step.jsx
+++ b/sections/resources/uas/UAS3Step.jsx
@@ -1,8 +1,15 @@
-import { StudentResource } from "../../../components";
+import styled from "styled-components";
+import Link from "next/link";
+
+import { StudentResource, Button } from "../../../components";
 import SampleGraphic from "../../../public/home/top-section-graphic.svg";
+import { media } from "../../../utils";
 
 export const UAS3Step = () => (
-  <div>
+  <Wrapper>
+    <TitleSection>
+      <Title>Our 3-Step Approach:</Title>
+    </TitleSection>
     <StudentResource
       titleText="1. FAQ Documents"
       descriptionText={`Concise descriptions of each university program that will be pinned in each Discord channel for easy access. FAQ sheets will address basic information about the university program, such as grade cutoffs, testing requirements, course requirements, and core curriculum.`}
@@ -25,5 +32,43 @@ export const UAS3Step = () => (
       graphicHeight={250}
       isCard={true}
     />
-  </div>
+    <div>
+      <Link href="reources/uas">
+        <a>
+    {/* TODO: change to discord server link */}
+          <Button>Join our Community of 800+ Students!</Button>
+        </a>
+      </Link>
+    </div>
+  </Wrapper>
 );
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 8vh;
+`;
+
+const TitleSection = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  ${media(
+    "tablet",
+    `
+      justify-content: center; 
+      `
+  )};
+`;
+
+const Title = styled.h2`
+  font-weight: 900;
+  padding-right: 20%;
+  ${media(
+    "tablet",
+    `
+      padding-right: 0;
+      `
+  )};
+`;

--- a/sections/resources/uas/UASLayout.jsx
+++ b/sections/resources/uas/UASLayout.jsx
@@ -13,18 +13,6 @@ export const UASLayout = () => (
         opportunities, and more.`,
       ]}
       graphic={SampleGraphic}
-      buttons={[
-        {
-          color: "yellow",
-          text: "Join our Community of 800+ Students",
-          link: "/resources/" /* TODO: change to Discord server invite link */,
-        },
-        {
-          color: "white",
-          text: "Learn more",
-          link: "/resources/uas",
-        },
-      ]}
     />
   </div>
 );

--- a/sections/resources/uas/UASLayout.jsx
+++ b/sections/resources/uas/UASLayout.jsx
@@ -17,7 +17,7 @@ export const UASLayout = () => (
         {
           color: "yellow",
           text: "Join our Community of 800+ Students",
-          link: "/resources/uas" /* TODO: change to Discord server invite link */,
+          link: "/resources/" /* TODO: change to Discord server invite link */,
         },
         {
           color: "white",

--- a/sections/resources/uas/index.js
+++ b/sections/resources/uas/index.js
@@ -1,1 +1,2 @@
 export { UASLayout } from "./UASLayout";
+export { UAS3Step } from "./UAS3Step";


### PR DESCRIPTION
## [MED] UAS 3 Step Approach 
Adds the UAS 3 Step section to UAS page. 
- Title has 20% right padding (in line *most of the time*), but doesn't stay in line with the right border of student resources (student resource width doesn't increase linearly) 

Differences from Figma: 
- instead of card carousel on mobile, steps become single columns (like student resources page) 
- text centers on mobile instead of staying right aligned (as consistent with `What is UAS` title and other text)
  - might need to change when background image is put in 
![screenshot_20210809_230802](https://user-images.githubusercontent.com/65516245/128802441-4e90848a-1e1e-41f8-afe0-a27ee73d84bd.png)
![screenshot_20210809_230655](https://user-images.githubusercontent.com/65516245/128802444-9e0860e1-db3b-4604-8d3a-90955eece12d.png)
